### PR TITLE
Update MNISTExample.py

### DIFF
--- a/cookbook/03-APIModel/MNISTExample/MNISTExample.py
+++ b/cookbook/03-APIModel/MNISTExample/MNISTExample.py
@@ -146,6 +146,7 @@ else:
     _0.padding_nd = [2, 2]
     _1 = network.add_activation(_0.get_output(0), trt.ActivationType.RELU)
     _2 = network.add_pooling_nd(_1.get_output(0), trt.PoolingType.MAX, [2, 2])
+    _2.stride_nd = [2, 2]
 
     w = para['w2:0'].transpose(3, 2, 0, 1).reshape(-1)
     b = para['b2:0']
@@ -153,6 +154,7 @@ else:
     _3.padding_nd = [2, 2]
     _4 = network.add_activation(_3.get_output(0), trt.ActivationType.RELU)
     _5 = network.add_pooling_nd(_4.get_output(0), trt.PoolingType.MAX, [2, 2])
+    _5.stride_nd = [2, 2]
 
     _6 = network.add_shuffle(_5.get_output(0))
     _6.first_transpose = (0, 2, 3, 1)


### PR DESCRIPTION
bug fix in cookbook/03, where we should state stride_nd in TensorRT 8.2.3（the docker image provided in the repo), but not in TensorRT 8.0.3.4(It seem that the preset values are different). If not, the shape of pooling output is wrong, resulting in build engine failure.